### PR TITLE
Don't delete OrderItems with type 6 (Shipping Cost) when wrapping

### DIFF
--- a/src/Models/LocalizedOrder.php
+++ b/src/Models/LocalizedOrder.php
@@ -15,6 +15,10 @@ use IO\Services\OrderService;
 class LocalizedOrder extends ModelWrapper
 {
     /**
+     * The OrderItem types that will be wrapped. All other OrderItems will be stripped from the order.
+     */
+    const WRAPPED_ORDERITEM_TYPES = [1, 3, 6, 9];
+    /**
      * @var Order
      */
     public $order = null;
@@ -98,7 +102,7 @@ class LocalizedOrder extends ModelWrapper
 
         foreach( $order->orderItems as $key => $orderItem )
         {
-            if($orderItem->typeId == 1 || $orderItem->typeId == 3 || $orderItem->typeId == 9)
+            if(in_array($orderItem->typeId, self::WRAPPED_ORDERITEM_TYPES))
             {
                 
                 if( $orderItem->itemVariationId !== 0 )

--- a/src/Services/ItemLoader/Factories/ItemLoaderFactoryES.php
+++ b/src/Services/ItemLoader/Factories/ItemLoaderFactoryES.php
@@ -387,7 +387,7 @@ class ItemLoaderFactoryES implements ItemLoaderFactory
                                 {
                                     $variation['data']['calculatedPrices']['graduatedPrices'][] = [
                                         'minimumOrderQuantity' => (int)$graduatedPrice->minimumOrderQuantity,
-                                        'price'                => (float)$graduatedPrice->price,
+                                        'price'                => (float)$graduatedPrice->unitPrice,
                                         'formatted'            => $numberFormatFilter->formatMonetary($graduatedPrice->unitPrice, $graduatedPrice->currency)
                                     ];
                                 }
@@ -406,7 +406,7 @@ class ItemLoaderFactoryES implements ItemLoaderFactory
                         if($variation['data']['variation']['mayShowUnitPrice'] == true && $lot > 0 && strlen($unit))
                         {
                             $basePrice = [];
-                            list($basePrice['lot'], $basePrice['price'], $basePrice['unitKey']) = $basePriceService->getUnitPrice($lot, $salesPrice->price, $unit);
+                            list($basePrice['lot'], $basePrice['price'], $basePrice['unitKey']) = $basePriceService->getUnitPrice($lot, $salesPrice->unitPrice, $unit);
 
                             /**
                              * @var UnitRepositoryContract $unitRepository


### PR DESCRIPTION
Up to now, OrderItems with type 6 (== Shipping Cost) have been stripped from the Order during wrapping. This PR fixes that.

@plentymarkets/ceres-io 
@ggottwald 