### PR TITLE
Hotfix for external checkouts (privacy hint)

### DIFF
--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -85,6 +85,13 @@ class OrderService
         {
             $couponCode = $basket->couponCode;
         }
+
+        $isShippingPrivacyHintAccepted = $this->sessionStorage->getSessionValue(SessionStorageKeys::SHIPPING_PRIVACY_HINT_ACCEPTED);
+
+        if(is_null($isShippingPrivacyHintAccepted) || strlen($isShippingPrivacyHintAccepted))
+        {
+            $isShippingPrivacyHintAccepted = 'false';
+        }
         
 		$order = pluginApp(OrderBuilder::class)->prepare(OrderType::ORDER)
 		                            ->fromBasket()
@@ -94,7 +101,7 @@ class OrderService
 		                            ->withOrderProperty(OrderPropertyType::PAYMENT_METHOD, OrderOptionSubType::MAIN_VALUE, $checkoutService->getMethodOfPaymentId())
                                     ->withOrderProperty(OrderPropertyType::SHIPPING_PROFILE, OrderOptionSubType::MAIN_VALUE, $checkoutService->getShippingProfileId())
                                     ->withOrderProperty(OrderPropertyType::DOCUMENT_LANGUAGE, OrderOptionSubType::MAIN_VALUE, $this->sessionStorage->getLang())
-                                    ->withOrderProperty(OrderPropertyType::SHIPPING_PRIVACY_HINT_ACCEPTED, OrderOptionSubType::MAIN_VALUE, $this->sessionStorage->getSessionValue(SessionStorageKeys::SHIPPING_PRIVACY_HINT_ACCEPTED))
+                                    ->withOrderProperty(OrderPropertyType::SHIPPING_PRIVACY_HINT_ACCEPTED, OrderOptionSubType::MAIN_VALUE, $isShippingPrivacyHintAccepted)
 		                            ->done();
         
 		$order = $this->orderRepository->createOrder($order, $couponCode);

--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -88,7 +88,7 @@ class OrderService
 
         $isShippingPrivacyHintAccepted = $this->sessionStorage->getSessionValue(SessionStorageKeys::SHIPPING_PRIVACY_HINT_ACCEPTED);
 
-        if(is_null($isShippingPrivacyHintAccepted) || strlen($isShippingPrivacyHintAccepted))
+        if(is_null($isShippingPrivacyHintAccepted) || !strlen($isShippingPrivacyHintAccepted))
         {
             $isShippingPrivacyHintAccepted = 'false';
         }


### PR DESCRIPTION
Add a check before creating the order, if the shipping privacy hint is set. If not it's set to "false" by default.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 