### PR TITLE
FIX Routing without Slug for SingleItem

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 plentymarkets IO
-
+---
 Copyright © 2017 plentymarkets GmbH
 
 According to our dual licensing model, this program can be used either

--- a/src/Api/Resources/ContactMailResource.php
+++ b/src/Api/Resources/ContactMailResource.php
@@ -8,6 +8,8 @@ use IO\Api\ApiResource;
 use IO\Api\ApiResponse;
 use IO\Api\ResponseCode;
 use IO\Services\ContactMailService;
+use Plenty\Plugin\Log\Loggable;
+
 
 /**
  * Class ContactMailResource
@@ -15,8 +17,9 @@ use IO\Services\ContactMailService;
  */
 class ContactMailResource extends ApiResource
 {
+    use Loggable;
     private $contactMailService;
-    
+
     /**
      * ContactMailResource constructor.
      * @param Request $request
@@ -27,14 +30,15 @@ class ContactMailResource extends ApiResource
         parent::__construct($request, $response);
         $this->contactMailService = $contactMailService;
     }
-    
+
     public function store():Response
     {
         $mailTemplate = $this->request->get('template', '');
         $contactData = $this->request->get('contactData',[]);
-        
+        $this->getLogger(__METHOD__)->error("contactData:", $contactData);
+
         $response = $this->contactMailService->sendMail($mailTemplate, $contactData);
-        
+
         if($response)
         {
             return $this->response->create($response, ResponseCode::CREATED);
@@ -43,6 +47,6 @@ class ContactMailResource extends ApiResource
         {
             return $this->response->create($response, ResponseCode::BAD_REQUEST);
         }
-        
+
     }
 }

--- a/src/Api/Resources/ContactMailResource.php
+++ b/src/Api/Resources/ContactMailResource.php
@@ -8,7 +8,6 @@ use IO\Api\ApiResource;
 use IO\Api\ApiResponse;
 use IO\Api\ResponseCode;
 use IO\Services\ContactMailService;
-use Plenty\Plugin\Log\Loggable;
 
 
 /**

--- a/src/Api/Resources/ContactMailResource.php
+++ b/src/Api/Resources/ContactMailResource.php
@@ -17,7 +17,6 @@ use Plenty\Plugin\Log\Loggable;
  */
 class ContactMailResource extends ApiResource
 {
-    use Loggable;
     private $contactMailService;
 
     /**
@@ -35,7 +34,6 @@ class ContactMailResource extends ApiResource
     {
         $mailTemplate = $this->request->get('template', '');
         $contactData = $this->request->get('contactData',[]);
-        $this->getLogger(__METHOD__)->error("contactData:", $contactData);
 
         $response = $this->contactMailService->sendMail($mailTemplate, $contactData);
 

--- a/src/Helper/RouteConfig.php
+++ b/src/Helper/RouteConfig.php
@@ -12,7 +12,7 @@ class RouteConfig
     const CONFIRMATION              = "confirmation";
     const LOGIN                     = "login";
     const REGISTER                  = "register";
-    const PLACE_ORDER               = "place_order";
+    const PLACE_ORDER               = "place-order";
     const SEARCH                    = "search";
     const HOME                      = "home";
     const CANCELLATION_RIGHTS       = "cancellation-rights";

--- a/src/Middlewares/Middleware.php
+++ b/src/Middlewares/Middleware.php
@@ -15,6 +15,7 @@ use IO\Controllers\StaticPagesController;
 use IO\Services\CheckoutService;
 use IO\Services\LocalizationService;
 use IO\Services\SessionStorageService;
+use IO\Services\CountryService; 
 use Plenty\Modules\Authentication\Contracts\ContactAuthenticationRepositoryContract;
 use IO\Guards\AuthGuard;
 

--- a/src/Middlewares/Middleware.php
+++ b/src/Middlewares/Middleware.php
@@ -16,7 +16,6 @@ use IO\Controllers\StaticPagesController;
 use IO\Services\CheckoutService;
 use IO\Services\LocalizationService;
 use IO\Services\SessionStorageService;
-use IO\Services\CountryService; 
 use Plenty\Modules\Authentication\Contracts\ContactAuthenticationRepositoryContract;
 use IO\Guards\AuthGuard;
 

--- a/src/Providers/IORouteServiceProvider.php
+++ b/src/Providers/IORouteServiceProvider.php
@@ -222,7 +222,7 @@ class IORouteServiceProvider extends RouteServiceProvider
          */
         if ( RouteConfig::isActive(RouteConfig::ITEM) )
         {
-            $router->get('{itemId}_{variationId}', 'IO\Controllers\ItemController@showItemWithoutName')
+            $router->get('_{itemId}_{variationId}', 'IO\Controllers\ItemController@showItemWithoutName')
                 ->where('itemId', '[0-9]+')
                 ->where('variationId', '[0-9]+');
 

--- a/src/Providers/IORouteServiceProvider.php
+++ b/src/Providers/IORouteServiceProvider.php
@@ -222,11 +222,11 @@ class IORouteServiceProvider extends RouteServiceProvider
          */
         if ( RouteConfig::isActive(RouteConfig::ITEM) )
         {
-            $router->get('_{itemId}_{variationId}', 'IO\Controllers\ItemController@showItemWithoutName')
+            $router->get('_{itemId}_{variationId?}', 'IO\Controllers\ItemController@showItemWithoutName')
                 ->where('itemId', '[0-9]+')
                 ->where('variationId', '[0-9]+');
 
-            $router->get('{slug}_{itemId}_{variationId}', 'IO\Controllers\ItemController@showItem')
+            $router->get('{slug}_{itemId}_{variationId?}', 'IO\Controllers\ItemController@showItem')
                 ->where('slug', '[^_]+')
                 ->where('itemId', '[0-9]+')
                 ->where('variationId', '[0-9]+');

--- a/src/Providers/IORouteServiceProvider.php
+++ b/src/Providers/IORouteServiceProvider.php
@@ -204,12 +204,12 @@ class IORouteServiceProvider extends RouteServiceProvider
             $router->get('order-property-file/{hash1}/{hash2}', 'IO\Controllers\OrderPropertyFileController@downloadFile');
         }
 
-        
+
         if( RouteConfig::isActive(RouteConfig::NEWSLETTER_OPT_IN) )
         {
             $router->get('newsletter/subscribe/{authString}/{newsletterEmailId}', 'IO\Controllers\NewsletterOptInController@showOptInConfirmation');
         }
-        
+
         if( RouteConfig::isActive(RouteConfig::NEWSLETTER_OPT_OUT) )
         {
             $router->get('newsletter/unsubscribe', 'IO\Controllers\NewsletterOptOutController@showOptOut');
@@ -221,11 +221,11 @@ class IORouteServiceProvider extends RouteServiceProvider
          */
         if ( RouteConfig::isActive(RouteConfig::ITEM) )
         {
-            $router->get('{itemId}_{variationId?}', 'IO\Controllers\ItemController@showItemWithoutName')
+            $router->get('{itemId}_{variationId}', 'IO\Controllers\ItemController@showItemWithoutName')
                 ->where('itemId', '[0-9]+')
                 ->where('variationId', '[0-9]+');
 
-            $router->get('{slug}_{itemId}_{variationId?}', 'IO\Controllers\ItemController@showItem')
+            $router->get('{slug}_{itemId}_{variationId}', 'IO\Controllers\ItemController@showItem')
                 ->where('slug', '[^_]+')
                 ->where('itemId', '[0-9]+')
                 ->where('variationId', '[0-9]+');


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 
Die Artikel Ansicht ist aktuell nicht über /_ArtikelId_VariantenId erreichbar, sondern nur über /artikelId_variantenId.