### PR TITLE
FIX category url builder prepending language twice

### DIFF
--- a/src/Services/UrlBuilder/CategoryUrlBuilder.php
+++ b/src/Services/UrlBuilder/CategoryUrlBuilder.php
@@ -48,6 +48,11 @@ class CategoryUrlBuilder
 
     private function buildUrlQuery( $path, $lang ): UrlQuery
     {
+        if(substr($path, 0, 4) === '/'.$lang.'/')
+        {
+            // FIX: category url already contains language, if it is different to default language
+            $path = substr($path, 4);
+        }
         return pluginApp(
             UrlQuery::class,
             ['path' => $path, 'lang' => $lang]


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 