### PR TITLE
fix: x-default hreflang

### DIFF
--- a/src/Services/UrlService.php
+++ b/src/Services/UrlService.php
@@ -188,7 +188,10 @@ class UrlService
             "languageUrls",
             function() {
                 $result = [];
-                $defaultUrl = $this->getCanonicalURL();
+
+                $defaultLanguage = $this->webstoreConfigurationService->getDefaultLanguage();
+
+                $defaultUrl = $this->getCanonicalURL( $defaultLanguage );
 
                 if ( $defaultUrl !== null )
                 {


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested
- [x] Plugin can be built

@plentymarkets/ceres-io 

Problem:

At present each language uses the current canonical url as x-default hreflang value. Therefore search engines won’t be able to find any default language, since all language urls are signed as x-default in the specific language.

The x-default hreflang value should signal that a page (of a multilingual website) doesn’t target any specific language or locale and is the default page when no other page is better suited.

Solution:

Always use the default language url as x-default hreflang value (since we don’t have any configuration for an ‘international’ language).

More Information:

https://webmasters.googleblog.com/2013/04/x-default-hreflang-for-international-pages.html