### PR TITLE
Fix/homepage sb contenttype

### DIFF
--- a/src/Controllers/HomepageController.php
+++ b/src/Controllers/HomepageController.php
@@ -3,6 +3,7 @@ namespace IO\Controllers;
 
 use IO\Helper\RouteConfig;
 use IO\Services\CategoryService;
+use Plenty\Modules\ShopBuilder\Helper\ShopBuilderRequest;
 
 /**
  * Class HomepageController
@@ -23,13 +24,18 @@ class HomepageController extends LayoutController
             ]
         );
     }
-    
+
     public function showHomepageCategory()
     {
         /** @var CategoryService $categoryService */
         $categoryService = pluginApp(CategoryService::class);
         $homepageCategory = $categoryService->get(RouteConfig::getCategoryId(RouteConfig::HOME));
-        
+
+        /** @var ShopBuilderRequest $shopBuilderRequest */
+        $shopBuilderRequest = pluginApp(ShopBuilderRequest::class);
+        $shopBuilderRequest->setMainContentType($homepageCategory->type);
+        $shopBuilderRequest->setMainCategory($homepageCategory->id);
+
         return $this->renderTemplate(
             "tpl.home.category",
             [


### PR DESCRIPTION
HomepageController bevorzugt globalen Header über eigenen Header.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 