### PR TITLE
Fix: LiveShopping beenden, wenn Netto-Warenbestand leer ist und darauf limitiert

### DIFF
--- a/src/Services/ItemSearch/SearchPresets/LiveShoppingItems.php
+++ b/src/Services/ItemSearch/SearchPresets/LiveShoppingItems.php
@@ -12,23 +12,19 @@ class LiveShoppingItems implements SearchPreset
     public static function getSearchFactory($options)
     {
         /** @var VariationSearchFactory $searchFactory */
-        $searchFactory = pluginApp( VariationSearchFactory::class );
+        $searchFactory = pluginApp(VariationSearchFactory::class);
 
-        if(isset($options['resultFields']) && count($options['resultFields']))
-        {
+        if (isset($options['resultFields']) && count($options['resultFields'])) {
             $searchFactory->withResultFields($options['resultFields']);
-        }
-        else
-        {
+        } else {
             $searchFactory->withResultFields(
                 array_merge(
-                    ResultFieldTemplate::load( ResultFieldTemplate::TEMPLATE_LIST_ITEM ),
+                    ResultFieldTemplate::load(ResultFieldTemplate::TEMPLATE_LIST_ITEM),
                     ['stock.net', 'variation.stockLimitation']
                 )
 
             );
         }
-
 
         $searchFactory
             ->withLanguage()
@@ -45,21 +41,17 @@ class LiveShoppingItems implements SearchPreset
             ->withLinkToContent()
             ->withReducedResults();
 
-        if(array_key_exists('itemId', $options) && $options['itemId'] != 0)
-        {
+        if (array_key_exists('itemId', $options) && $options['itemId'] != 0) {
             $searchFactory->hasItemId($options['itemId']);
         }
 
-        if(array_key_exists('itemIds', $options) && count($options['itemIds']))
-        {
+        if (array_key_exists('itemIds', $options) && count($options['itemIds'])) {
             $searchFactory->hasItemIds($options['itemIds']);
         }
 
-        if(array_key_exists('sorting', $options) && count($options['sorting']))
-        {
+        if (array_key_exists('sorting', $options) && count($options['sorting'])) {
             $searchFactory->sortBy($options['sorting']['path'], $options['sorting']['order']);
         }
-
 
         return $searchFactory;
     }

--- a/src/Services/ItemSearch/SearchPresets/LiveShoppingItems.php
+++ b/src/Services/ItemSearch/SearchPresets/LiveShoppingItems.php
@@ -13,7 +13,7 @@ class LiveShoppingItems implements SearchPreset
     {
         /** @var VariationSearchFactory $searchFactory */
         $searchFactory = pluginApp( VariationSearchFactory::class );
-        
+
         if(isset($options['resultFields']) && count($options['resultFields']))
         {
             $searchFactory->withResultFields($options['resultFields']);
@@ -21,11 +21,15 @@ class LiveShoppingItems implements SearchPreset
         else
         {
             $searchFactory->withResultFields(
-                ResultFieldTemplate::load( ResultFieldTemplate::TEMPLATE_LIST_ITEM )
+                array_merge(
+                    ResultFieldTemplate::load( ResultFieldTemplate::TEMPLATE_LIST_ITEM ),
+                    ['stock.net', 'variation.stockLimitation']
+                )
+
             );
         }
-        
-        
+
+
         $searchFactory
             ->withLanguage()
             ->withImages()
@@ -40,23 +44,23 @@ class LiveShoppingItems implements SearchPreset
             ->hasPriceForCustomer()
             ->withLinkToContent()
             ->withReducedResults();
-        
+
         if(array_key_exists('itemId', $options) && $options['itemId'] != 0)
         {
             $searchFactory->hasItemId($options['itemId']);
         }
-    
+
         if(array_key_exists('itemIds', $options) && count($options['itemIds']))
         {
             $searchFactory->hasItemIds($options['itemIds']);
         }
-    
+
         if(array_key_exists('sorting', $options) && count($options['sorting']))
         {
             $searchFactory->sortBy($options['sorting']['path'], $options['sorting']['order']);
         }
-        
-        
+
+
         return $searchFactory;
     }
 }

--- a/src/Services/LiveShoppingService.php
+++ b/src/Services/LiveShoppingService.php
@@ -25,35 +25,35 @@ class LiveShoppingService
         {
             $sorting = 'sorting.price.avg_asc';
         }
-        
+
         /** @var LiveShoppingRepositoryContract $liveShoppingRepo */
         $liveShoppingRepo = pluginApp(LiveShoppingRepositoryContract::class);
         /** @var LiveShopping $liveShopping */
         $liveShopping = $liveShoppingRepo->getLiveShopping($liveShoppingId);
-        
+
         $liveShoppingItem = [];
         $liveShoppingData = [];
-        
+
         if($liveShopping instanceof LiveShopping)
         {
             $itemList = $this->getLiveShoppingVariations($liveShopping->itemId, $sorting);
-            
+
             if(count($itemList[0]['documents']))
             {
                 $liveShoppingItem = array_slice($itemList[0]['documents'], 0, 1);
             }
-            
+
             $liveShoppingData = $liveShopping->toArray();
-            $liveShoppingData['quantitySold'] = $liveShoppingData['quantitySold'] + $liveShoppingData['quantitySoldReal'];
+            $liveShoppingData['quantitySold'] += $liveShoppingData['quantitySoldReal'];
             unset($liveShoppingData['quantitySoldReal']);
         }
-        
+
         return [
             'item' => $liveShoppingItem[0]['data'],
             'liveShopping' => $liveShoppingData
         ];
     }
-    
+
     public function getLiveShoppingVariations($itemId, $sorting)
     {
         $itemSearchOptions = [
@@ -65,11 +65,11 @@ class LiveShoppingService
         $itemList = $itemSearchService->getResults([
                                                        LiveShoppingItems::getSearchFactory( $itemSearchOptions )
                                                    ]);
-        
-       
+
+
         return $this->filterLiveShoppingVariations($itemList);
     }
-    
+
     /**
      * @param $itemList
      * @return array
@@ -93,7 +93,7 @@ class LiveShoppingService
                 }
             }
         }
-        
+
         return $itemList;
     }
 }

--- a/src/Services/LiveShoppingService.php
+++ b/src/Services/LiveShoppingService.php
@@ -21,8 +21,7 @@ class LiveShoppingService
      */
     public function getLiveShoppingData($liveShoppingId, $sorting = null)
     {
-        if(is_null($sorting))
-        {
+        if (is_null($sorting)) {
             $sorting = 'sorting.price.avg_asc';
         }
 
@@ -34,12 +33,10 @@ class LiveShoppingService
         $liveShoppingItem = [];
         $liveShoppingData = [];
 
-        if($liveShopping instanceof LiveShopping)
-        {
+        if ($liveShopping instanceof LiveShopping) {
             $itemList = $this->getLiveShoppingVariations($liveShopping->itemId, $sorting);
 
-            if(count($itemList[0]['documents']))
-            {
+            if (count($itemList[0]['documents'])) {
                 $liveShoppingItem = array_slice($itemList[0]['documents'], 0, 1);
             }
 
@@ -57,15 +54,16 @@ class LiveShoppingService
     public function getLiveShoppingVariations($itemId, $sorting)
     {
         $itemSearchOptions = [
-            'itemId'        => $itemId,
-            'sorting'       => SortingHelper::splitPathAndOrder($sorting)
+            'itemId' => $itemId,
+            'sorting' => SortingHelper::splitPathAndOrder($sorting)
         ];
         /** @var ItemSearchService $itemSearchService */
-        $itemSearchService = pluginApp( ItemSearchService::class );
-        $itemList = $itemSearchService->getResults([
-                                                       LiveShoppingItems::getSearchFactory( $itemSearchOptions )
-                                                   ]);
-
+        $itemSearchService = pluginApp(ItemSearchService::class);
+        $itemList = $itemSearchService->getResults(
+            [
+                LiveShoppingItems::getSearchFactory($itemSearchOptions)
+            ]
+        );
 
         return $this->filterLiveShoppingVariations($itemList);
     }
@@ -76,16 +74,11 @@ class LiveShoppingService
      */
     public function filterLiveShoppingVariations($itemList)
     {
-        if(count($itemList))
-        {
-            foreach($itemList as $listKey => $list)
-            {
-                if(count($list['documents']))
-                {
-                    foreach($list['documents'] as $key => $variation)
-                    {
-                        if(is_null($variation['data']['prices']['specialOffer']))
-                        {
+        if (count($itemList)) {
+            foreach ($itemList as $listKey => $list) {
+                if (count($list['documents'])) {
+                    foreach ($list['documents'] as $key => $variation) {
+                        if (is_null($variation['data']['prices']['specialOffer'])) {
                             unset($itemList[$listKey]['documents'][$key]);
                             $itemList[$listKey]['documents'][] = $variation;
                         }


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 