### PR TITLE
Feature Remove Guest E-Mail Modal and Add E-Mail Field to AddressInputGroup

### DIFF
--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -45,7 +45,7 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") && $customerService->getContactId() <= 0 )
+            if( !$sessionStorage->getSessionValue("skipLogin")  && (!$sessionStorage->getSessionValue("usedLoginPage") || $customerService->getContactId() <= 0) )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn", [
                     "skipLogin" => $sessionStorage->getSessionValue("skipLogin"),

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -45,9 +45,10 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( $sessionStorage->getSessionValue("skipLogin") == false )
+            if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
+                $sessionStorage->setValue("usedLoginPage", true);
                 AuthGuard::redirect(
                     $shopUrls->login,
                     ["backlink" => AuthGuard::getUrl()]

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -50,10 +50,7 @@ class CheckoutController extends LayoutController
 
             if( !$sessionStorage->getSessionValue("skipLogin")  && ($request->get("isGuest") == 0 && $customerService->getContactId() <= 0))
             {
-                $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn", [
-                    "skipLogin" => $sessionStorage->getSessionValue("skipLogin"),
-                    "isGuest" => $request->get("isGuest")
-                ]);
+                $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
                 AuthGuard::redirect(
                     $shopUrls->login,
                     ["backlink" => AuthGuard::getUrl()]

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -45,8 +45,7 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( $sessionStorage->getSessionValue(SessionStorageKeys::GUEST_EMAIL) == null
-                && $customerService->getContactId() <= 0 )
+            if( !$sessionStorage->getSessionValue("skipLogin") )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
                 AuthGuard::redirect(

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -45,7 +45,7 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( !$sessionStorage->getSessionValue("skipLogin") )
+            if( $sessionStorage->getSessionValue("skipLogin") == false )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
                 AuthGuard::redirect(

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -45,7 +45,7 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") )
+            if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") && $customerService->getContactId() <= 0 )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
                 $sessionStorage->setSessionValue("usedLoginPage", true);

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -48,7 +48,7 @@ class CheckoutController extends LayoutController
             if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") )
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
-                $sessionStorage->setValue("usedLoginPage", true);
+                $sessionStorage->setSessionValue("usedLoginPage", true);
                 AuthGuard::redirect(
                     $shopUrls->login,
                     ["backlink" => AuthGuard::getUrl()]

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -10,6 +10,7 @@ use Plenty\Modules\Basket\Contracts\BasketItemRepositoryContract;
 use IO\Guards\AuthGuard;
 use Plenty\Modules\Category\Models\Category;
 use Plenty\Modules\ShopBuilder\Helper\ShopBuilderRequest;
+use Plenty\Plugin\Http\Request;
 use Plenty\Plugin\Log\Loggable;
 
 /**
@@ -45,13 +46,14 @@ class CheckoutController extends LayoutController
 
         if ( !$shopBuilderRequest->isShopBuilder() )
         {
-            if( !$sessionStorage->getSessionValue("skipLogin")  && (!$sessionStorage->getSessionValue("usedLoginPage") || $customerService->getContactId() <= 0) )
+            $request = pluginApp(Request::class);
+
+            if( !$sessionStorage->getSessionValue("skipLogin")  && ($request->get("isGuest") == 0 && $customerService->getContactId() <= 0))
             {
                 $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn", [
                     "skipLogin" => $sessionStorage->getSessionValue("skipLogin"),
-                    "usedLoginPage" => $sessionStorage->getSessionValue("usedLoginPage")
+                    "isGuest" => $request->get("isGuest")
                 ]);
-                $sessionStorage->setSessionValue("usedLoginPage", true);
                 AuthGuard::redirect(
                     $shopUrls->login,
                     ["backlink" => AuthGuard::getUrl()]

--- a/src/Controllers/CheckoutController.php
+++ b/src/Controllers/CheckoutController.php
@@ -47,7 +47,10 @@ class CheckoutController extends LayoutController
         {
             if( !$sessionStorage->getSessionValue("skipLogin")  && !$sessionStorage->getSessionValue("usedLoginPage") && $customerService->getContactId() <= 0 )
             {
-                $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn");
+                $this->getLogger(__CLASS__)->info("IO::Debug.CheckoutController_notLoggedIn", [
+                    "skipLogin" => $sessionStorage->getSessionValue("skipLogin"),
+                    "usedLoginPage" => $sessionStorage->getSessionValue("usedLoginPage")
+                ]);
                 $sessionStorage->setSessionValue("usedLoginPage", true);
                 AuthGuard::redirect(
                     $shopUrls->login,

--- a/src/Services/CustomerService.php
+++ b/src/Services/CustomerService.php
@@ -727,13 +727,13 @@ class CustomerService
     private function buildAddressEmailOptions(array $options = [], $isGuest = false, $addressData = []): array
     {
         if ($isGuest) {
-            /** @var SessionStorageService $sessionStorage */
-            $sessionStorage = pluginApp(SessionStorageService::class);
-            $email = $sessionStorage->getSessionValue(SessionStorageKeys::GUEST_EMAIL);
-
-            if (!strlen($email)) {
+       
+            if (isset($addressData['email'])) {
+                $email = $addressData['email'];
+            } else {
                 throw new \Exception('no guest email address found', 11);
             }
+            
         } else {
             $email = $this->getContact()->email;
         }


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 
Die Logik für das prüfen, ob es eine Gastbestellung ist wurde so geändert, dass der Checkout auch ohne vorherige Eingabe der E-Mail erreicht werden kann. Die Eingabe der E-Mail Adresse erfolgt jetzt im Modal für die Rechnungsadresse. 