### PR TITLE
Fix return type when liveshopping is empty

### DIFF
--- a/src/Services/LiveShoppingService.php
+++ b/src/Services/LiveShoppingService.php
@@ -48,12 +48,14 @@ class LiveShoppingService
             $this->checkStockLimit($liveShoppingData, $liveShoppingItem);
 
             unset($liveShoppingItem['stock'], $liveShoppingItem['variation']['stockLimitation']);
+
+            return [
+                'item' => $liveShoppingItem,
+                'liveShopping' => $liveShoppingData
+            ];
         }
 
-        return [
-            'item' => $liveShoppingItem,
-            'liveShopping' => $liveShoppingData
-        ];
+        return null;
     }
 
     public function getLiveShoppingVariations($itemId, $sorting)


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 