### PR TITLE
use priceGross and priceNet instead of original

### DIFF
--- a/src/Services/OrderTotalsService.php
+++ b/src/Services/OrderTotalsService.php
@@ -62,8 +62,8 @@ class OrderTotalsService
             switch ($item->typeId) {
                 case OrderItemType::VARIATION:
                 case OrderItemType::ITEM_BUNDLE:
-                    $itemSumGross += $firstAmount->priceOriginalGross * $item->quantity;
-                    $itemSumNet += $firstAmount->priceOriginalNet * $item->quantity;
+                    $itemSumGross += $firstAmount->priceGross * $item->quantity;
+                    $itemSumNet += $firstAmount->priceNet * $item->quantity;
                     break;
                 case OrderItemType::SHIPPING_COSTS:
                     $locationId = $vatService->getLocationId($item->countryVatId);


### PR DESCRIPTION
Damit im Gesamtwarenwert die Aufpreise für Merkmale berücksichtigt werden.

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 