### PR TITLE
FIX matching of confirmation page if called with params

### DIFF
--- a/src/Extensions/Constants/ShopUrls.php
+++ b/src/Extensions/Constants/ShopUrls.php
@@ -72,7 +72,8 @@ class ShopUrls
         $this->resetMemoryCache();
         $this->appendTrailingSlash = UrlQuery::shouldAppendTrailingSlash();
         $this->trailingSlashSuffix = $this->appendTrailingSlash ? '/' : '';
-        $this->includeLanguage = $lang !== $webstoreConfigurationRepository->getWebstoreConfiguration()->defaultLanguage;
+        $this->includeLanguage = $lang !== $webstoreConfigurationRepository->getWebstoreConfiguration(
+            )->defaultLanguage;
 
         $this->basket = $this->getShopUrl(RouteConfig::BASKET);
         $this->cancellationForm = $this->getShopUrl(RouteConfig::CANCELLATION_FORM);
@@ -258,8 +259,7 @@ class ShopUrls
             return RouteConfig::ITEM;
         } elseif (preg_match('/_t\d+\/?$/m', $url) === 1) {
             return RouteConfig::TAGS;
-        }
-        elseif (preg_match('/confirmation\/\d+\/([A-Z]|\d)+\/?/m', $url) === 1) {
+        } elseif (preg_match('/confirmation\/\d+\/([A-Z]|\d)+\/?/m', $url) === 1) {
             return RouteConfig::CONFIRMATION;
         }
 

--- a/src/Extensions/Constants/ShopUrls.php
+++ b/src/Extensions/Constants/ShopUrls.php
@@ -259,6 +259,9 @@ class ShopUrls
         } elseif (preg_match('/_t\d+\/?$/m', $url) === 1) {
             return RouteConfig::TAGS;
         }
+        elseif (preg_match('/confirmation\/\d+\/([A-Z]|\d)+\/?/m', $url) === 1) {
+            return RouteConfig::CONFIRMATION;
+        }
 
         // template type cannot be determined
         return RouteConfig::CATEGORY;

--- a/src/Extensions/Constants/ShopUrls.php
+++ b/src/Extensions/Constants/ShopUrls.php
@@ -259,7 +259,7 @@ class ShopUrls
             return RouteConfig::ITEM;
         } elseif (preg_match('/_t\d+\/?$/m', $url) === 1) {
             return RouteConfig::TAGS;
-        } elseif (preg_match('/confirmation\/\d+\/([A-Z]|\d)+\/?/m', $url) === 1) {
+        } elseif (preg_match('/confirmation\/\d+\/([A-Za-z]|\d)+\/?/m', $url) === 1) {
             return RouteConfig::CONFIRMATION;
         }
 


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 