### PR TITLE
set the type for item categories to "categoryitem", to load the correct shopbuilder header / footer

### DIFF
--- a/src/Controllers/CategoryController.php
+++ b/src/Controllers/CategoryController.php
@@ -141,7 +141,14 @@ class CategoryController extends LayoutController
 
         /** @var ShopBuilderRequest $shopBuilderRequest */
         $shopBuilderRequest = pluginApp(ShopBuilderRequest::class);
-        $shopBuilderRequest->setMainContentType($category->type);
+
+        if ($category->type === 'item') {
+            // the shopbuilder type for item categories is 'categoryitem'
+            $shopBuilderRequest->setMainContentType('categoryitem');
+        }
+        else {
+            $shopBuilderRequest->setMainContentType($category->type);
+        }
         $shopBuilderRequest->setMainCategory($category->id);
 
         if (RouteConfig::getCategoryId(RouteConfig::CHECKOUT) === $category->id || $shopBuilderRequest->getPreviewContentType() === 'checkout') {


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 