### PR TITLE
add sort for activeCountries

### DIFF
--- a/src/Services/CountryService.php
+++ b/src/Services/CountryService.php
@@ -54,6 +54,9 @@ class CountryService
                 self::$activeCountries[$lang][] = $country;
             }
         }
+        // sort Country List
+        $column = array_column(self::$activeCountries[$lang], "currLangName");
+        array_multisort($column, SORT_ASC, SORT_LOCALE_STRING, self::$activeCountries[$lang]);
 
         return self::$activeCountries[$lang];
     }

--- a/src/Services/CountryService.php
+++ b/src/Services/CountryService.php
@@ -54,7 +54,10 @@ class CountryService
                 self::$activeCountries[$lang][] = $country;
             }
         }
-        // sort Country List
+        /**
+         * Todo: Remove JS Sort in Ceres
+         * Sort active Country List
+         */
         $column = array_column(self::$activeCountries[$lang], "currLangName");
         array_multisort($column, SORT_ASC, SORT_LOCALE_STRING, self::$activeCountries[$lang]);
 


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 

Aktuell wird die Sortierung der Lieferländer in Ceres in der [/resources/js/src/app/store/index.js](https://github.com/plentymarkets/plugin-ceres/blob/stable/resources/js/src/app/store/index.js) via Javascript vorgenommen. Je nach Anzahl der Lieferländer führt das zu einer hohen Javascript Ausführungszeit. 

Theoretisch könnte man so auch später relativ einfach die Sortierung der Lieferländer Konfigurierbar machen. 

Solltet Ihr den PR mergen, dann müsstet Ihr noch das JS aus Ceres entfernen, dafür mache ich erst einmal keinen PR. 

Grüße
Jens