### PR TITLE
FIX twig function queryString using RFC 3986 instead if RFC 1738

### DIFF
--- a/src/Extensions/Functions/QueryString.php
+++ b/src/Extensions/Functions/QueryString.php
@@ -52,7 +52,7 @@ class QueryString extends AbstractFunction
             return '';
         }
 
-        $queryParameters = http_build_query($queryParameters);
+        $queryParameters = http_build_query($queryParameters, null, '&', PHP_QUERY_RFC3986);
         return strlen($queryParameters) > 0 ? '?' . $queryParameters : '';
     }
 }


### PR DESCRIPTION
### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io 