### PR TITLE
Configurable bundle prefixes: use setting

### DIFF
--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -25,6 +25,7 @@ use Plenty\Modules\Order\Date\Models\OrderDateType;
 use Plenty\Modules\Order\Models\OrderReference;
 use Plenty\Modules\Order\Property\Contracts\OrderPropertyRepositoryContract;
 use Plenty\Modules\Order\Property\Models\OrderProperty;
+use Plenty\Modules\Order\Settings\Contracts\OrderSettingsRepositoryContract;
 use Plenty\Modules\Order\Status\Contracts\OrderStatusRepositoryContract;
 use Plenty\Modules\Payment\Contracts\PaymentRepositoryContract;
 use Plenty\Modules\Payment\Method\Contracts\PaymentMethodRepositoryContract;
@@ -758,6 +759,49 @@ class OrderService
             SessionStorageRepositoryContract::LATEST_ORDER_ID,
             $order->id
         );
+    }
+
+    /**
+     * Remove the bundle prefix from the order item name.
+     * Default prefix is "[BUNDLE] "
+     * 
+     * @param string $name
+     * @return string
+     */
+    public function removeBundlePrefix(string $name): string
+    {
+        return $this->removeOrderItemPrefix($name, \Plenty\Modules\Order\Models\OrderItemType::TYPE_ITEM_BUNDLE);
+    }
+
+    /**
+     * Remove the bundle component prefix from the order item name.
+     * Default prefix is "[-] "
+     * 
+     * @param string $name
+     * @return string
+     */
+    public function removeBundleComponentPrefix(string $name): string
+    {
+        return $this->removeOrderItemPrefix($name, \Plenty\Modules\Order\Models\OrderItemType::TYPE_BUNDLE_COMPONENT);
+    }
+
+    /**
+     * @param string $name
+     * @param int $orderItemTypeId
+     * @return string
+     */
+    private function removeOrderItemPrefix(string $name, int $orderItemTypeId): string
+    {
+        /** @var OrderSettingsRepositoryContract $settingsRepository */
+        $settingsRepository = pluginApp(OrderSettingsRepositoryContract::class);
+        $settings = $settingsRepository->get();
+        $prefix = $settings->orderItemPrefixes[$orderItemTypeId] ?? null;
+
+        if ($prefix !== null && (substr($name, 0, strlen($prefix)) == $prefix)) {
+            $name = substr($name, strlen($prefix));
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Services/OrderService.php
+++ b/src/Services/OrderService.php
@@ -792,16 +792,41 @@ class OrderService
      */
     private function removeOrderItemPrefix(string $name, int $orderItemTypeId): string
     {
-        /** @var OrderSettingsRepositoryContract $settingsRepository */
-        $settingsRepository = pluginApp(OrderSettingsRepositoryContract::class);
-        $settings = $settingsRepository->get();
-        $prefix = $settings->orderItemPrefixes[$orderItemTypeId] ?? null;
-
+        $prefix = $this->getOrderItemPrefix($orderItemTypeId);
         if ($prefix !== null && (substr($name, 0, strlen($prefix)) == $prefix)) {
             $name = substr($name, strlen($prefix));
         }
 
         return $name;
+    }
+
+    /**
+     * Check if the prefix for components is included in the name
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function containsComponentPrefix(string $name): bool
+    {
+        $prefix = $this->getOrderItemPrefix(\Plenty\Modules\Order\Models\OrderItemType::TYPE_BUNDLE_COMPONENT);
+        if ($prefix !== null && (substr($name, 0, strlen($prefix)) == $prefix)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get prefix for item type id
+     *
+     * @param int $orderItemTypeId
+     * @return int|null
+     */
+    public function getOrderItemPrefix(int $orderItemTypeId)
+    {
+        /** @var OrderSettingsRepositoryContract $settingsRepository */
+        $settingsRepository = pluginApp(OrderSettingsRepositoryContract::class);
+        $settings = $settingsRepository->get();
+        return $settings->orderItemPrefixes[$orderItemTypeId] ?? null;
     }
 
     /**


### PR DESCRIPTION
Wir haben eine Einstellung für die Präfixe bei Bundles geschaffen (früher fest `[BUNDLE]` und `[-]`). Das soll dann hier über die Einstellung geladen werden.

@plentymarkets/ceres-io bitte gut prüfen, ich hab noch nie was bei Ceres gemacht 🙂 . Der String `[BUNDLE]` wird auch noch in `itemBundleName.filter.js` verwendet. Muss die Stelle auch angepasst werden? In der Bestellübersicht und in MyAccount hatte mit der Anpassung in `ItemName.twig` gepasst soweit ich das sehen konnte.

Ceres-Teil: https://github.com/plentymarkets/plugin-ceres/pull/3019

Zum Testen müsste auf PY / PS / Order-Package dieser Branch verwendet werden: `order/feature/order_item_prefixes`

**Darf erst gemerged werden, wenn die Basisimplementierung für die Einstellung in Stable ist.**

### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/ceres-io
@plentymarkets/team-order-payment 

https://plentymarkets.kanbanize.com/ctrl_board/75/cards/202079/details/