### PR TITLE
CHANGE LocalizedOrder.php - put the whole order, instead of orderItems in the method

### DIFF
--- a/src/Models/LocalizedOrder.php
+++ b/src/Models/LocalizedOrder.php
@@ -322,7 +322,7 @@ class LocalizedOrder extends ModelWrapper
         /** @var VariationPropertyConverter $variationPropertyConverter */
         $variationPropertyConverter = pluginApp(VariationPropertyConverter::class);
         $instance->order->relations['orderItems'] = $variationPropertyConverter->convertVariationPropertyOrderItems(
-            $instance->order->relations['orderItems']
+            $instance->order
         );
 
         /** @var OrderTotalsService $orderTotalsService */


### PR DESCRIPTION

### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Plugin can be built

@plentymarkets/ceres-io
