### PR TITLE
Recalculate checkout vat depending on payment method

### DIFF
--- a/src/Api/ApiResponse.php
+++ b/src/Api/ApiResponse.php
@@ -350,13 +350,13 @@ class ApiResponse
             /** @var CheckoutService $checkoutService */
             $checkoutService = pluginApp(CheckoutService::class);
 
+            $responseData['events']['CheckoutChanged']['checkout'] = $checkoutService->getCheckout();
             $responseData['events']['AfterBasketChanged']['basket'] = $basketService->getBasketForTemplate();
             $responseData['events']['AfterBasketChanged']['showNetPrices'] = $contactRepository->showNetPrices();
             $responseData['events']['AfterBasketChanged']['basketItems'] = $basketService->getBasketItemsForTemplate(
                 '',
                 false
             );
-            $responseData['events']['CheckoutChanged']['checkout'] = $checkoutService->getCheckout();
         }
 
         $responseData["data"] = $data;


### PR DESCRIPTION
In clearVat case of eClear plugin the VAT rates are determined depending on the payment method.
When the address is changed (invoice or delivery), it comes to an incorrect result in the basket/checkout if the currently selected payment method is no longer available.
@stentrop 

### All changes meet the following requirements
- [x] Changelog entry was added
- [x] Changes have been documented
- [x] Changes have been tested by the author
- [x] Changes have been tested by the reviewer
- [x] Plugin can be built

@plentymarkets/plentyshop
