### PR TITLE
fix: {"error":{"message":"Non-static method IO\\Extensions\\Constants…

### DIFF
--- a/src/Services/TemplateService.php
+++ b/src/Services/TemplateService.php
@@ -253,6 +253,8 @@ class TemplateService
      */
     public function isRegister(): bool
     {
-        return ShopUrls::is(RouteConfig::REGISTER);
+        /** @var ShopUrls $shopUrls */
+        $shopUrls = pluginApp(ShopUrls::class);
+        return $shopUrls->is(RouteConfig::REGISTER);
     }
 }


### PR DESCRIPTION
…\\ShopUrls::is() cannot be called statically","code":0}}

### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Changes to routes were replicated in webshop package
- [ ] Plugin can be built

@plentymarkets/plentyshop
